### PR TITLE
Add a combined installer for SDK and other changes

### DIFF
--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -10,23 +10,23 @@ SET(CPACK_WIX_UPGRADE_GUID "69CA0E2A-65D4-4191-BA1D-DBE4CA856D0C")
 
 add_executable(osvr_server IMPORTED)
 set_property(TARGET osvr_server
-            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/bin/osvr_server.exe")
+            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Core/bin/osvr_server.exe")
 
 add_executable(OSVRTrackerView IMPORTED)
 set_property(TARGET OSVRTrackerView
-            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Tracker-Viewer/x64/OSVRTrackerView.exe")
+            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Tracker-Viewer/OSVRTrackerView.exe")
 
 add_executable(EnableOSVRDirectMode IMPORTED)
 set_property(TARGET EnableOSVRDirectMode
-            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/EnableOSVRDirectMode.exe")
+            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/RM/EnableOSVRDirectMode.exe")
 
 add_executable(DisableOSVRDirectMode IMPORTED)
 set_property(TARGET DisableOSVRDirectMode
-            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/DisableOSVRDirectMode.exe")
+            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/RM/DisableOSVRDirectMode.exe")
 
 add_executable(RenderManagerD3DPresentExample3D IMPORTED)
 set_property(TARGET RenderManagerD3DPresentExample3D
-            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/RenderManagerD3DPresentExample3D.exe")
+            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/RM/RenderManagerD3DPresentExample3D.exe")
 
 add_executable(osvr_central IMPORTED)
 set_property(TARGET osvr_central
@@ -36,40 +36,27 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Documentation/"
         COMPONENT "Documentation"
         DESTINATION "Runtime/Documentation")
 
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Tracker-Viewer/x86/"
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Tracker-Viewer/"
         COMPONENT "Server"
-        DESTINATION "Runtime/bin/x86")
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Tracker-Viewer/x64/"
-        COMPONENT "Server"
-        DESTINATION "Runtime/bin/x64")
+        DESTINATION "Runtime/bin")
 
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Central/x86/"
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Central/"
         COMPONENT "Server"
-        DESTINATION "Runtime/bin/x86")
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Central/x64/"
-        COMPONENT "Server"
-        DESTINATION "Runtime/bin/x64")
+        DESTINATION "Runtime/bin")
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Config/"
         COMPONENT "Server"
         DESTINATION "Runtime/config")
 
 #copy all binaries from osvr server for both dev and client builds
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x86/bin/"
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Core/"
         COMPONENT "Server"
-        DESTINATION "Runtime/bin/x86")
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/bin/"
-        COMPONENT "Server"
-        DESTINATION "Runtime/bin/x64")
-
+        DESTINATION "Runtime")
 
 #copy binaries from render manager for both dev and client builds
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x86/bin/"
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RM/bin/"
         COMPONENT "Server"
-        DESTINATION "Runtime/bin/x86")
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/bin/"
-        COMPONENT "Server"
-        DESTINATION "Runtime/bin/x64")
+        DESTINATION "Runtime/bin")
 
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
         COMPONENT "Server"
@@ -77,10 +64,7 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
 
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/NOTICE"
         COMPONENT "Server"
-        DESTINATION "Runtime/bin/x86")
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/NOTICE"
-        COMPONENT "Server"
-        DESTINATION "Runtime/bin/x64")
+        DESTINATION "Runtime/bin")
 
 
 # additional components for SDK build
@@ -88,41 +72,23 @@ if(${TYPE} STREQUAL "DEV")
     SET(OSVR_PACKAGE_NAME "OSVR SDK")
     SET(CPACK_WIX_UPGRADE_GUID "1825FD58-B969-40B6-AE40-04613561EB82")
 
-    # copy all OSVR Core headers to include dir
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/include/"
-        COMPONENT "Headers"
-        DESTINATION "SDK/include")
-
-    # copy all OSVR Core 32/64 bit libs
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x86/lib/"
-        COMPONENT "Libraries"
-        DESTINATION "SDK/lib/x86")
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/lib/"
-        COMPONENT "Libraries"
-        DESTINATION "SDK/lib/x64")
-
+    # copy all OSVR Core
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x86/"
+        COMPONENT "SDK"
+        DESTINATION "SDK/x86")
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/"
+        COMPONENT "SDK"
+        DESTINATION "SDK/x64")
+        
     # copy all RenderManager headers to include
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/include/"
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x86/"
         COMPONENT "Headers"
-        DESTINATION "SDK/include")
+        DESTINATION "SDK/x86")
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/"
+        COMPONENT "SDK"
+        DESTINATION "SDK/x64")
 
-    # copy all RenderManager 32/64 bit libs
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x86/lib/"
-        COMPONENT "Libraries"
-        DESTINATION "SDK/lib/x86")
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/lib/"
-        COMPONENT "Libraries"
-        DESTINATION "SDK/lib/x64")
-
-    # copy OSVR Core 32 and 64 bit share to samples
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x86/share/"
-        COMPONENT "Samples"
-        DESTINATION "SDK/samples/x86")
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/share/"
-        COMPONENT "Samples"
-        DESTINATION "SDK/samples/x64")
-
-    set(CPACK_COMPONENTS_ALL Documentation Server Headers Libraries Samples)
+    set(CPACK_COMPONENTS_ALL Documentation Server SDK)
     set(CPACK_PACKAGE_FILE_NAME "SDK")
 
 # runtime installer details

--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -49,12 +49,12 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Config/"
         DESTINATION "Runtime/config")
 
 #copy all binaries from osvr server for both dev and client builds
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Core/"
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Core-Release/"
         COMPONENT "Server"
         DESTINATION "Runtime")
 
 #copy binaries from render manager for both dev and client builds
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RM/"
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager-Release/"
         COMPONENT "Server"
         DESTINATION "Runtime")
 
@@ -73,10 +73,10 @@ if(${TYPE} STREQUAL "DEV")
     SET(CPACK_WIX_UPGRADE_GUID "1825FD58-B969-40B6-AE40-04613561EB82")
 
     # copy all OSVR Core
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x86/"
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Core/x86/"
         COMPONENT "SDK"
         DESTINATION "SDK/x86")
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/"
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Core/x64/"
         COMPONENT "SDK"
         DESTINATION "SDK/x64")
 

--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -56,7 +56,7 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Core/"
 #copy binaries from render manager for both dev and client builds
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RM/"
         COMPONENT "Server"
-        DESTINATION "Runtime/bin")
+        DESTINATION "Runtime")
 
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
         COMPONENT "Server"

--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -77,7 +77,11 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
 
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/NOTICE"
         COMPONENT "Server"
-        DESTINATION "Runtime/bin")
+        DESTINATION "Runtime/bin/x86")
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/NOTICE"
+        COMPONENT "Server"
+        DESTINATION "Runtime/bin/x64")
+
 
 # additional components for SDK build
 if(${TYPE} STREQUAL "DEV")

--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -5,104 +5,130 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 SET(TYPE "DEV" CACHE STRING "Either client or dev build type")
 SET(CORE_VER "v0.6-1114-gc3ae55c" CACHE STRING "OSVR Core version")
 SET(OSVR_PACKAGE_NAME "OSVR Runtime")
-SET(BIT "32" CACHE STRING "32 or 64 bit build")
+SET(CPACK_WIX_UPGRADE_GUID "69CA0E2A-65D4-4191-BA1D-DBE4CA856D0C")
 
 
 add_executable(osvr_server IMPORTED)
 set_property(TARGET osvr_server
-            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/osvr_server.exe")
+            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/bin/osvr_server.exe")
 
 add_executable(OSVRTrackerView IMPORTED)
 set_property(TARGET OSVRTrackerView
-            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Tracker-Viewer/OSVRTrackerView.exe")
+            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Tracker-Viewer/x64/OSVRTrackerView.exe")
 
 add_executable(EnableOSVRDirectMode IMPORTED)
 set_property(TARGET EnableOSVRDirectMode
-            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/EnableOSVRDirectMode.exe")
+            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/EnableOSVRDirectMode.exe")
 
 add_executable(DisableOSVRDirectMode IMPORTED)
 set_property(TARGET DisableOSVRDirectMode
-            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/DisableOSVRDirectMode.exe")
+            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/DisableOSVRDirectMode.exe")
 
 add_executable(RenderManagerD3DPresentExample3D IMPORTED)
 set_property(TARGET RenderManagerD3DPresentExample3D
-            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/RenderManagerD3DPresentExample3D.exe")
+            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/RenderManagerD3DPresentExample3D.exe")
+
+add_executable(osvr_central IMPORTED)
+set_property(TARGET osvr_central
+            PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Central/x64/osvr_central.exe")
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Documentation/"
         COMPONENT "Documentation"
-        DESTINATION "Documentation")
+        DESTINATION "Runtime/Documentation")
 
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Tracker-Viewer/"
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Tracker-Viewer/x86/"
         COMPONENT "Server"
-        DESTINATION "bin")
-        
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Central/"
+        DESTINATION "Runtime/bin/x86")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Tracker-Viewer/x64/"
         COMPONENT "Server"
-        DESTINATION "bin")
-        
+        DESTINATION "Runtime/bin/x64")
+
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Central/x86/"
+        COMPONENT "Server"
+        DESTINATION "Runtime/bin/x86")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Central/x64/"
+        COMPONENT "Server"
+        DESTINATION "Runtime/bin/x64")
+
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Config/"
         COMPONENT "Server"
-        DESTINATION "config")
+        DESTINATION "Runtime/config")
 
 #copy all binaries from osvr server for both dev and client builds
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/bin/"
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x86/bin/"
         COMPONENT "Server"
-        DESTINATION "bin")
+        DESTINATION "Runtime/bin/x86")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/bin/"
+        COMPONENT "Server"
+        DESTINATION "Runtime/bin/x64")
+
 
 #copy binaries from render manager for both dev and client builds
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/bin/"
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x86/bin/"
         COMPONENT "Server"
-        DESTINATION "bin")
+        DESTINATION "Runtime/bin/x86")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/bin/"
+        COMPONENT "Server"
+        DESTINATION "Runtime/bin/x64")
 
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
         COMPONENT "Server"
-        DESTINATION ".")
+        DESTINATION "Runtime")
 
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/NOTICE"
         COMPONENT "Server"
-        DESTINATION "bin")
+        DESTINATION "Runtime/bin")
 
 # additional components for SDK build
 if(${TYPE} STREQUAL "DEV")
     SET(OSVR_PACKAGE_NAME "OSVR SDK")
-
+    SET(CPACK_WIX_UPGRADE_GUID "1825FD58-B969-40B6-AE40-04613561EB82")
+    
     # copy all OSVR Core headers to include dir
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/include/"
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/include/"
         COMPONENT "Headers"
-        DESTINATION "include")
+        DESTINATION "SDK/include")
 
-    # copy all OSVR Core libs
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/lib/"
+    # copy all OSVR Core 32/64 bit libs
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x86/lib/"
         COMPONENT "Libraries"
-        DESTINATION "lib")
-
+        DESTINATION "SDK/lib/x86")
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/lib/"
+        COMPONENT "Libraries"
+        DESTINATION "SDK/lib/x64")
+        
     # copy all RenderManager headers to include
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/include/"
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/include/"
         COMPONENT "Headers"
-        DESTINATION "include")
+        DESTINATION "SDK/include")
 
-    # copy all RenderManager libs
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/lib/"
+    # copy all RenderManager 32/64 bit libs
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x86/lib/"
         COMPONENT "Libraries"
-        DESTINATION "lib")
-
-    # copy OSVR Core share to samples
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/share/"
+        DESTINATION "SDK/lib/x86")
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/lib/"
+        COMPONENT "Libraries"
+        DESTINATION "SDK/lib/x64")
+        
+    # copy OSVR Core 32 and 64 bit share to samples
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x86/share/"
         COMPONENT "Samples"
-        DESTINATION "samples")
+        DESTINATION "SDK/samples/x86")
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/share/"
+        COMPONENT "Samples"
+        DESTINATION "SDK/samples/x64")
 
     set(CPACK_COMPONENTS_ALL Documentation Server Headers Libraries Samples)
-    set(CPACK_PACKAGE_INSTALL_DIRECTORY "OSVR/SDK")
     set(CPACK_PACKAGE_FILE_NAME "SDK")
 
 # runtime installer details
 else()
     set(CPACK_COMPONENTS_ALL Documentation Server)
-    set(CPACK_PACKAGE_INSTALL_DIRECTORY "OSVR/Runtime")
     set(CPACK_PACKAGE_FILE_NAME "Runtime")
 endif()
 
-set(CPACK_PACKAGE_VENDOR "OSVR")
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "OSVR")
+set(CPACK_PACKAGE_VENDOR "Sensics Inc.")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${OSVR_PACKAGE_NAME})
 string(REGEX REPLACE "v([0-9]).*" "\\1" CPACK_PACKAGE_VERSION_MAJOR ${CORE_VER})
 string(REGEX REPLACE "v[0-9].([0-9]).*" "\\1" CPACK_PACKAGE_VERSION_MINOR ${CORE_VER})
@@ -111,6 +137,7 @@ set(CPACK_PACKAGE_NAME ${OSVR_PACKAGE_NAME})
 
 #executables should be set in pairs "exe" "exe name" (specify all executables at once)
 set(CPACK_PACKAGE_EXECUTABLES   osvr_server "OSVR Server"
+                                osvr_central "OSVR Central"
                                 EnableOSVRDirectMode "Enable DirectMode"
                                 DisableOSVRDirectMode "Disable DirectMode"
                                 RenderManagerD3DPresentExample3D "D3D Example"
@@ -118,7 +145,6 @@ set(CPACK_PACKAGE_EXECUTABLES   osvr_server "OSVR Server"
 #set(CPACK_CREATE_DESKTOP_LINKS osvr_server)
 
 SET(CPACK_GENERATOR WIX)
-SET(CPACK_WIX_UPGRADE_GUID "69CA0E2A-65D4-4191-BA1D-DBE4CA856D0C")
 SET(CPACK_WIX_PRODUCT_ICON "${CMAKE_CURRENT_SOURCE_DIR}/assets/osvr_server.ico")
 SET(CPACK_WIX_UI_DIALOG "${CMAKE_CURRENT_SOURCE_DIR}/assets/osvr_server_icon_Dialog.png")
 SET(CPACK_WIX_UI_BANNER "${CMAKE_CURRENT_SOURCE_DIR}/assets/osvr_server_icon_Banner.png")

--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -82,7 +82,7 @@ if(${TYPE} STREQUAL "DEV")
 
     # copy all RenderManager headers to include
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x86/"
-        COMPONENT "Headers"
+        COMPONENT "SDK"
         DESTINATION "SDK/x86")
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/"
         COMPONENT "SDK"

--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -83,7 +83,7 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/NOTICE"
 if(${TYPE} STREQUAL "DEV")
     SET(OSVR_PACKAGE_NAME "OSVR SDK")
     SET(CPACK_WIX_UPGRADE_GUID "1825FD58-B969-40B6-AE40-04613561EB82")
-    
+
     # copy all OSVR Core headers to include dir
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/include/"
         COMPONENT "Headers"
@@ -96,7 +96,7 @@ if(${TYPE} STREQUAL "DEV")
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/lib/"
         COMPONENT "Libraries"
         DESTINATION "SDK/lib/x64")
-        
+
     # copy all RenderManager headers to include
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/include/"
         COMPONENT "Headers"
@@ -109,7 +109,7 @@ if(${TYPE} STREQUAL "DEV")
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x64/lib/"
         COMPONENT "Libraries"
         DESTINATION "SDK/lib/x64")
-        
+
     # copy OSVR Core 32 and 64 bit share to samples
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x86/share/"
         COMPONENT "Samples"

--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -54,7 +54,7 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Core/"
         DESTINATION "Runtime")
 
 #copy binaries from render manager for both dev and client builds
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RM/bin/"
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RM/"
         COMPONENT "Server"
         DESTINATION "Runtime/bin")
 

--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -79,7 +79,7 @@ if(${TYPE} STREQUAL "DEV")
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OSVR-Server/x64/"
         COMPONENT "SDK"
         DESTINATION "SDK/x64")
-        
+
     # copy all RenderManager headers to include
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/RenderManager/x86/"
         COMPONENT "Headers"

--- a/ci-pre-build.ps1
+++ b/ci-pre-build.ps1
@@ -27,23 +27,13 @@ function Main() {
     Rename-Dir "OSVR-Core\BIT=32" "x86"
     Rename-Dir "OSVR-Core\BIT=64" "x64"
 
-    Write-Host "Renaming OSVR-Central folders"
-    Rename-Dir "OSVR-Central\BIT=32,VS=12,host=windows" "x86"
-    Rename-Dir "OSVR-Central\BIT=64,VS=12,host=windows" "x64"
-
-    Write-Host "Renaming OSVR-Tracker-Viewer folders"
-    Rename-Dir "OSVR-Tracker-Viewer\BIT=32,label=windows" "x86"
-    Rename-Dir "OSVR-Tracker-Viewer\BIT=64,label=windows" "x64"
-
     Write-Host "Moving 32 bit RenderManager contents up one dir"
     MoveUpOneDir("RenderManager\x86\install")
     Write-Host "Moving 64 bit RenderManager contents up one dir"
     MoveUpOneDir("RenderManager\x64\install")
 
-    Write-Host "Moving 32 bit OSVR-Central contents up one dir"
-    MoveUpOneDir("OSVR-Central\x86\bin")
-    Write-Host "Moving 64 bit OSVR-Central contents up one dir"
-    MoveUpOneDir("OSVR-Central\x64\bin")
+    Write-Host "Moving OSVR-Central contents up one dir"
+    MoveUpOneDir("OSVR-Central\bin")
 
     Write-Host "Moving 32 bit OSVR-Core contents up one dir"
     MoveUpOneDir("OSVR-Core\x86\install")
@@ -54,12 +44,10 @@ function Main() {
     MoveUpOneDir("OSVR-Config\artifacts")
 
     Write-Host "Removing extra files from OSVR-Central"
-    Move-OSVR-Central "OSVR-Central\x86"
-    Move-OSVR-Central "OSVR-Central\x64"
+    Move-OSVR-Central "OSVR-Central"
 
     Write-Host "Removing extra files from OSVR Tracker Viewer"
-    Move-OSVR-Tracker-View "OSVR-Tracker-Viewer\x86"
-    Move-OSVR-Tracker-View "OSVR-Tracker-Viewer\x64"
+    Move-OSVR-Tracker-View "OSVR-Tracker-Viewer"
 
     Write-Host "Removing extra files from RenderManager"
     Move-RenderManager "RenderManager\x86"

--- a/ci-pre-build.ps1
+++ b/ci-pre-build.ps1
@@ -18,16 +18,47 @@ $buildType = $env:TYPE
 
 # "Entry Point" function
 function Main() {
-    Write-Host "Moving RenderManager contents up one dir"
-    MoveUpOneDir("RenderManager\install")
+
+    Write-Host "Renaming RenderManager folders"
+    Rename-Dir("RenderManager\BIT=32,label=windows", "x86")
+    Rename-Dir("RenderManager\BIT=64,label=windows", "x64")
+
+    Write-Host "Renaming OSVR-Core folders"
+    Rename-Dir("OSVR-Core\BIT=32", "x86")
+    Rename-Dir("OSVR-Core\BIT=64", "x64")
+
+    Write-Host "Renaming OSVR-Central folders"
+    Rename-Dir("OSVR-Central\BIT=32,VS=12,host=windows", "x86")
+    Rename-Dir("OSVR-Central\BIT=64,VS=12,host=windows", "x64")
+
+    Write-Host "Renaming OSVR-Tracker-Viewer folders"
+    Rename-Dir("OSVR-Tracker-Viewer\BIT=32,label=windows", "x86")
+    Rename-Dir("OSVR-Tracker-Viewer\BIT=64,label=windows", "x64")
+
+    Write-Host "Moving 32 bit RenderManager contents up one dir"
+    MoveUpOneDir("RenderManager\x86\install")
+    Write-Host "Moving 64 bit RenderManager contents up one dir"
+    MoveUpOneDir("RenderManager\x64\install")
+
+    Write-Host "Moving 32 bit OSVR-Central contents up one dir"
+    MoveUpOneDir("OSVR-Central\x86\bin")
+    Write-Host "Moving 64 bit OSVR-Central contents up one dir"
+    MoveUpOneDir("OSVR-Central\x64\bin")
+
+    Write-Host "Moving 32 bit OSVR-Core contents up one dir"
+    MoveUpOneDir("OSVR-Core\x86\install")
+    Write-Host "Moving 64 bit OSVR-Core contents up one dir"
+    MoveUpOneDir("OSVR-Core\x64\install")
+
     Write-Host "Moving OSVR-Config contents up one dir"
     MoveUpOneDir("OSVR-Config\artifacts")
-    Write-Host "Moving OSVR-Central contents up one dir"
-    MoveUpOneDir("OSVR-Central\bin")
+
     Write-Host "Removing extra files from OSVR-Central"
     Move-OSVR-Central
+
     Write-Host "Removing extra files from OSVR Tracker Viewer"
     Move-OSVR-Tracker-View
+
     Write-Host "Removing extra files from RenderManager"
     Move-RenderManager
 
@@ -143,6 +174,10 @@ function Move-OSVR-Central(){
 
     $OSVRPaths = $OSVRFiles| % {Join-Path $centralDir "$_"}
     Remove-Item $OSVRPaths
+}
+
+function Rename-Dir([string]$oldName, [string]$newName){
+    Rename-Item -path $oldName -newName $newName
 }
 
 # call the entry point

--- a/ci-pre-build.ps1
+++ b/ci-pre-build.ps1
@@ -113,7 +113,6 @@ function Move-RenderManager(){
         #Extra files to remove for client build
         $RMFiles = 'AdjustableRenderingDelayD3D.exe',
             'AdjustableRenderingDelayOpenGL.exe',
-            'DirectModeDebugging.exe',
             'LatencyTestD3DExample.exe',
             'RenderManagerD3DExample3D.exe',
             'RenderManagerD3DHeadSpaceExample.exe',

--- a/ci-pre-build.ps1
+++ b/ci-pre-build.ps1
@@ -53,9 +53,13 @@ function Main() {
     Write-Host "Removing extra files from OSVR Tracker Viewer"
     Move-OSVR-Tracker-View "OSVR-Tracker-Viewer"
 
-    Write-Host "Removing extra files from RenderManager"
-    Move-RenderManager "RenderManager\x86"
-    Move-RenderManager "RenderManager\x64"
+    if($buildType.compareTo("DEV") -eq 0){
+        Write-Host "Removing extra files from RenderManager-SDK"
+        Move-RenderManager-SDK "RenderManager\x86"
+        Move-RenderManager-SDK "RenderManager\x64"
+    }
+    Write-Host "Removing extra files from RenderManager-Release"
+    Move-RenderManager "RenderManager-Release"
 
     Write-Host "ci-build complete!"
 }
@@ -101,6 +105,7 @@ function Move-OSVR-Core() {
 }
 
 function Move-OSVR-Tracker-View([string]$trackViewDir) {
+
     # Extra files to remove OSVR Tracker Viewer
     $OSVRFiles = 'osvr-ver.txt',
         'osvrClientKit.dll',
@@ -130,6 +135,44 @@ function Move-OSVR-Tracker-View([string]$trackViewDir) {
 function Move-RenderManager([string]$RMDir){
 
     # Extra files to remove OSVR RenderManager
+    $ExtraFiles = 'osvrClientKit.dll',
+        'osvrClient.dll',
+        'osvrUtil.dll',
+        'osvrCommon.dll',
+        'osvr-ver.txt',
+        'AdjustableRenderingDelayD3D.exe',
+        'AdjustableRenderingDelayOpenGL.exe',
+        'LatencyTestD3DExample.exe',
+        'RenderManagerD3DExample3D.exe',
+        'RenderManagerD3DHeadSpaceExample.exe',
+        'RenderManagerD3DPresentMakeDeviceExample3D.exe',
+        'RenderManagerD3DPresentSideBySideExample.exe',
+        'RenderManagerD3DTest2D.exe',
+        'RenderManagerOpenGLCoreExample.exe',
+        'RenderManagerOpenGLExample.exe',
+        'RenderManagerOpenGLHeadSpaceExample.exe',
+        'RenderManagerOpenGLPresentExample.exe',
+        'RenderManagerOpenGLPresentSideBySideExample.exe',
+        'SpinCubeD3D.exe',
+        'SpinCubeOpenGL.exe'
+
+    $ExtraDirs = 'include',
+                 'lib'
+
+    $binDir = "bin"
+    $RMPath = Join-Path $RMDir $binDir
+    $RMPaths = $ExtraFiles| % {Join-Path $RMPath "$_"}
+    Remove-Item $RMPaths
+
+    Write-Host "Removing extra dirs from RenderManager-Release"
+    $RMPaths = $ExtraDirs| % {Join-Path $RMDir "$_"}
+    Remove-Item -Path $RMPaths -Recurse -Force
+
+}
+
+function Move-RenderManager-SDK([string]$RMDir){
+
+    # Extra files to remove OSVR RenderManager
     $OSVRFiles = 'osvrClientKit.dll',
         'osvrClient.dll',
         'osvrUtil.dll',
@@ -137,36 +180,13 @@ function Move-RenderManager([string]$RMDir){
         'osvrClientKitd.dll',
         'osvrClientd.dll',
         'osvrUtild.dll',
-        'osvrCommond.dll'
+        'osvrCommond.dll,
+        osvr-ver.txt'
 
     $binDir = "bin"
     $RMPath = Join-Path $RMDir $binDir
     $RMPaths = $OSVRFiles| % {Join-Path $RMPath "$_"}
     Remove-Item $RMPaths
-
-
-    if($buildType.compareTo("CLIENT") -eq 0)
-    {
-        Write-Host "Removing additional files from RenderManager for client build"
-        #Extra files to remove for client build
-        $RMFiles = 'AdjustableRenderingDelayD3D.exe',
-            'AdjustableRenderingDelayOpenGL.exe',
-            'LatencyTestD3DExample.exe',
-            'RenderManagerD3DExample3D.exe',
-            'RenderManagerD3DHeadSpaceExample.exe',
-            'RenderManagerD3DPresentMakeDeviceExample3D.exe',
-            'RenderManagerD3DPresentSideBySideExample.exe',
-            'RenderManagerD3DTest2D.exe',
-            'RenderManagerOpenGLCoreExample.exe',
-            'RenderManagerOpenGLExample.exe',
-            'RenderManagerOpenGLHeadSpaceExample.exe',
-            'RenderManagerOpenGLPresentExample.exe',
-            'RenderManagerOpenGLPresentSideBySideExample.exe',
-            'SpinCubeD3D.exe',
-            'SpinCubeOpenGL.exe'
-        $RMPaths = $RMFiles| % {Join-Path $RMPath "$_"}
-        Remove-Item $RMPaths
-    }
 }
 
 function Move-OSVR-Central([string]$centralDir){

--- a/ci-pre-build.ps1
+++ b/ci-pre-build.ps1
@@ -28,12 +28,12 @@ function Main() {
     Rename-Dir "OSVR-Core\BIT=64" "x64"
 
     Write-Host "Renaming OSVR-Central folders"
-    Rename-Dir "OSVR-Central\BIT=32,VS=12,host=windows" "x86" 
-    Rename-Dir "OSVR-Central\BIT=64,VS=12,host=windows" "x64" 
+    Rename-Dir "OSVR-Central\BIT=32,VS=12,host=windows" "x86"
+    Rename-Dir "OSVR-Central\BIT=64,VS=12,host=windows" "x64"
 
     Write-Host "Renaming OSVR-Tracker-Viewer folders"
-    Rename-Dir "OSVR-Tracker-Viewer\BIT=32,label=windows" "x86" 
-    Rename-Dir "OSVR-Tracker-Viewer\BIT=64,label=windows" "x64" 
+    Rename-Dir "OSVR-Tracker-Viewer\BIT=32,label=windows" "x86"
+    Rename-Dir "OSVR-Tracker-Viewer\BIT=64,label=windows" "x64"
 
     Write-Host "Moving 32 bit RenderManager contents up one dir"
     MoveUpOneDir("RenderManager\x86\install")

--- a/ci-pre-build.ps1
+++ b/ci-pre-build.ps1
@@ -31,6 +31,8 @@ function Main() {
     MoveUpOneDir("RenderManager\x86\install")
     Write-Host "Moving 64 bit RenderManager contents up one dir"
     MoveUpOneDir("RenderManager\x64\install")
+    Write-Host "Moving RenderManager-Release contents up one dir"
+    MoveUpOneDir("RenderManager-Release\install")
 
     Write-Host "Moving OSVR-Central contents up one dir"
     MoveUpOneDir("OSVR-Central\bin")
@@ -39,6 +41,8 @@ function Main() {
     MoveUpOneDir("OSVR-Core\x86\install")
     Write-Host "Moving 64 bit OSVR-Core contents up one dir"
     MoveUpOneDir("OSVR-Core\x64\install")
+    Write-Host "Moving OSVR-Core-Release contents up one dir"
+    MoveUpOneDir("OSVR-Core-Release\install")
 
     Write-Host "Moving OSVR-Config contents up one dir"
     MoveUpOneDir("OSVR-Config\artifacts")
@@ -57,9 +61,9 @@ function Main() {
 }
 
 function MoveUpOneDir([string]$dirPath){
-    $files = get-childitem -path . -filter $dirPath
+    $files = Get-Childitem -path . -filter $dirPath
         foreach ($file in $files) {
-            $subFiles = get-childitem -path $file.FullName
+            $subFiles = Get-Childitem -path $file.FullName
             foreach ($subFile in $subFiles) {
                 $tempName = $file.Parent.FullName + "\" + $subFile.Name + '-foo'
                 $newName = $file.Parent.FullName + "\" + $subFile.Name
@@ -67,22 +71,33 @@ function MoveUpOneDir([string]$dirPath){
                 #write-host "Old Location: " $subFile.FullName
                 #write-host "New Location:" $newName
 
-                write-host "Moving: " + $subFile
-                move-item -path $subFile.FullName -dest $tempName
-                move-item -path $tempName -dest $newName
+                Write-Host "Moving: " + $subFile
+                Move-Item -path $subFile.FullName -dest $tempName
+                Move-Item -path $tempName -dest $newName
             }
         }
-    write-host "Removing empty dir" : $file.FullName
-    remove-item -path $file.FullName
+    Write-Host "Removing empty dir" : $file.FullName
+    Remove-Item -path $file.FullName
 }
 
 function Move-OSVR-Core() {
-    # Extra files to remove OSVR Core
-    $OSVRFiles = 'NOTICE'
 
-    $serverDir = "OSVR-Server"
+    # Extra dirs and files to remove OSVR Core Release
+    $OSVRDirs = 'include',
+                'lib',
+                'share'
+    $OSVRFiles = 'add_sdk_to_registry.ps1',
+                 'add_sdk_to_registry.cmd'
+
+
+    Write-Host "Removing extra files from OSVR-Core-Release"
+    $serverDir = "OSVR-Core-Release"
     $OSVRPaths = $OSVRFiles| % {Join-Path $serverDir "$_"}
     Remove-Item $OSVRPaths
+
+    Write-Host "Removing extra dirs from OSVR-Core-Release"
+    $OSVRPaths = $OSVRDirs| % {Join-Path $serverDir "$_"}
+    Remove-Item -Path $OSVRPaths -Recurse -Force
 }
 
 function Move-OSVR-Tracker-View([string]$trackViewDir) {
@@ -118,7 +133,11 @@ function Move-RenderManager([string]$RMDir){
     $OSVRFiles = 'osvrClientKit.dll',
         'osvrClient.dll',
         'osvrUtil.dll',
-        'osvrCommon.dll'
+        'osvrCommon.dll',
+        'osvrClientKitd.dll',
+        'osvrClientd.dll',
+        'osvrUtild.dll',
+        'osvrCommond.dll'
 
     $binDir = "bin"
     $RMPath = Join-Path $RMDir $binDir

--- a/ci-pre-build.ps1
+++ b/ci-pre-build.ps1
@@ -20,20 +20,20 @@ $buildType = $env:TYPE
 function Main() {
 
     Write-Host "Renaming RenderManager folders"
-    Rename-Dir("RenderManager\BIT=32,label=windows", "x86")
-    Rename-Dir("RenderManager\BIT=64,label=windows", "x64")
+    Rename-Dir "RenderManager\BIT=32,label=windows" "x86"
+    Rename-Dir "RenderManager\BIT=64,label=windows" "x64"
 
     Write-Host "Renaming OSVR-Core folders"
-    Rename-Dir("OSVR-Core\BIT=32", "x86")
-    Rename-Dir("OSVR-Core\BIT=64", "x64")
+    Rename-Dir "OSVR-Core\BIT=32" "x86"
+    Rename-Dir "OSVR-Core\BIT=64" "x64"
 
     Write-Host "Renaming OSVR-Central folders"
-    Rename-Dir("OSVR-Central\BIT=32,VS=12,host=windows", "x86")
-    Rename-Dir("OSVR-Central\BIT=64,VS=12,host=windows", "x64")
+    Rename-Dir "OSVR-Central\BIT=32,VS=12,host=windows" "x86" 
+    Rename-Dir "OSVR-Central\BIT=64,VS=12,host=windows" "x64" 
 
     Write-Host "Renaming OSVR-Tracker-Viewer folders"
-    Rename-Dir("OSVR-Tracker-Viewer\BIT=32,label=windows", "x86")
-    Rename-Dir("OSVR-Tracker-Viewer\BIT=64,label=windows", "x64")
+    Rename-Dir "OSVR-Tracker-Viewer\BIT=32,label=windows" "x86" 
+    Rename-Dir "OSVR-Tracker-Viewer\BIT=64,label=windows" "x64" 
 
     Write-Host "Moving 32 bit RenderManager contents up one dir"
     MoveUpOneDir("RenderManager\x86\install")

--- a/ci-pre-build.ps1
+++ b/ci-pre-build.ps1
@@ -54,13 +54,16 @@ function Main() {
     MoveUpOneDir("OSVR-Config\artifacts")
 
     Write-Host "Removing extra files from OSVR-Central"
-    Move-OSVR-Central
+    Move-OSVR-Central "OSVR-Central\x86"
+    Move-OSVR-Central "OSVR-Central\x64"
 
     Write-Host "Removing extra files from OSVR Tracker Viewer"
-    Move-OSVR-Tracker-View
+    Move-OSVR-Tracker-View "OSVR-Tracker-Viewer\x86"
+    Move-OSVR-Tracker-View "OSVR-Tracker-Viewer\x64"
 
     Write-Host "Removing extra files from RenderManager"
-    Move-RenderManager
+    Move-RenderManager "RenderManager\x86"
+    Move-RenderManager "RenderManager\x64"
 
     Write-Host "ci-build complete!"
 }
@@ -94,7 +97,7 @@ function Move-OSVR-Core() {
     Remove-Item $OSVRPaths
 }
 
-function Move-OSVR-Tracker-View() {
+function Move-OSVR-Tracker-View([string]$trackViewDir) {
     # Extra files to remove OSVR Tracker Viewer
     $OSVRFiles = 'osvr-ver.txt',
         'osvrClientKit.dll',
@@ -112,8 +115,6 @@ function Move-OSVR-Tracker-View() {
     $LicenseReadme = 'README-components-and-licenses.txt'
     $NewLicenseReadme = 'Tracker-Viewer-components-and-licenses.txt'
 
-    $trackViewDir = "OSVR-Tracker-Viewer"
-
     $OSVRPaths = $OSVRFiles| % {Join-Path $trackViewDir "$_"}
     Remove-Item $OSVRPaths
 
@@ -123,7 +124,7 @@ function Move-OSVR-Tracker-View() {
     Remove-Item -Recurse -Path $trackViewDir -Include *.7z
 }
 
-function Move-RenderManager(){
+function Move-RenderManager([string]$RMDir){
 
     # Extra files to remove OSVR RenderManager
     $OSVRFiles = 'osvrClientKit.dll',
@@ -131,7 +132,6 @@ function Move-RenderManager(){
         'osvrUtil.dll',
         'osvrCommon.dll'
 
-    $RMDir = "RenderManager"
     $binDir = "bin"
     $RMPath = Join-Path $RMDir $binDir
     $RMPaths = $OSVRFiles| % {Join-Path $RMPath "$_"}
@@ -162,15 +162,13 @@ function Move-RenderManager(){
     }
 }
 
-function Move-OSVR-Central(){
+function Move-OSVR-Central([string]$centralDir){
     # Extra files to remove OSVR-Central
     $OSVRFiles = 'osvrClient.dll',
         'osvrClientKit.dll',
         'osvrCommon.dll',
         'osvrPluginHost.dll',
         'osvrUtil.dll'
-
-    $centralDir = "OSVR-Central"
 
     $OSVRPaths = $OSVRFiles| % {Join-Path $centralDir "$_"}
     Remove-Item $OSVRPaths

--- a/cpack/ServerEnvVarPatch.xml
+++ b/cpack/ServerEnvVarPatch.xml
@@ -1,5 +1,5 @@
 <CPackWiXPatch>
-    <CPackWiXFragment Id="CM_CP_Server.bin.osvr_server.exe">
-        <Environment Id="OSVR_SERVER_ROOT" Name="OSVR_SERVER_ROOT" Value="[CM_DP_Server.bin]" Permanent="no" Part="all" Action="set" System="no" />
+    <CPackWiXFragment Id="CM_CP_Server.Runtime.bin.x64.osvr_server.exe">
+        <Environment Id="OSVR_SERVER_ROOT" Name="OSVR_SERVER_ROOT" Value="[CM_CP_Server.Runtime.bin.x64]" Permanent="no" Part="all" Action="set" System="no" />
     </CPackWiXFragment>
 </CPackWiXPatch>

--- a/cpack/ServerEnvVarPatch.xml
+++ b/cpack/ServerEnvVarPatch.xml
@@ -1,5 +1,5 @@
 <CPackWiXPatch>
-    <CPackWiXFragment Id="CM_CP_Server.Runtime.bin.x64.osvr_server.exe">
-        <Environment Id="OSVR_SERVER_ROOT" Name="OSVR_SERVER_ROOT" Value="[CM_DP_Server.Runtime.bin.x64]" Permanent="no" Part="all" Action="set" System="no" />
+    <CPackWiXFragment Id="CM_CP_Server.Runtime.bin.osvr_server.exe">
+        <Environment Id="OSVR_SERVER_ROOT" Name="OSVR_SERVER_ROOT" Value="[CM_DP_Server.Runtime.bin]" Permanent="no" Part="all" Action="set" System="no" />
     </CPackWiXFragment>
 </CPackWiXPatch>

--- a/cpack/ServerEnvVarPatch.xml
+++ b/cpack/ServerEnvVarPatch.xml
@@ -1,5 +1,5 @@
 <CPackWiXPatch>
     <CPackWiXFragment Id="CM_CP_Server.Runtime.bin.x64.osvr_server.exe">
-        <Environment Id="OSVR_SERVER_ROOT" Name="OSVR_SERVER_ROOT" Value="[CM_CP_Server.Runtime.bin.x64]" Permanent="no" Part="all" Action="set" System="no" />
+        <Environment Id="OSVR_SERVER_ROOT" Name="OSVR_SERVER_ROOT" Value="[CM_DP_Server.Runtime.bin.x64]" Permanent="no" Part="all" Action="set" System="no" />
     </CPackWiXFragment>
 </CPackWiXPatch>


### PR DESCRIPTION
This PR includes 
- Include both 32 and 64 bit OSVR libs for SDK
- Include both Runtime and SDK related bin/libs for SDK installer
- Removes extra folders/files
- Maintain proper dir structure for SDK libs
- Allow SDK and Runtime to be installed side by side (different GUIDs)

Addresses the following issues:
#22, #14, #18
